### PR TITLE
Pegging eth-abi to 1.1.1

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -58,6 +58,7 @@ devise_setup(name='devise',
                  'web3==4.2.1',
                  'rlp==0.6.0',
                  'pysha3==1.0.2',
+                 'eth-abi==1.1.1',
                  'eth-utils==1.0.3'
              ],
              extras_require={


### PR DESCRIPTION
This PR fixes a breaking change in eth-abi 1.2 that makes it depend on eth_utils.toolz which does not exist in 1.0.3